### PR TITLE
Fixed link to "part 2" in Valhalla_ubuntu_part_1_build_install.md

### DIFF
--- a/valhalla/Valhalla_ubuntu_part_1_build_install.md
+++ b/valhalla/Valhalla_ubuntu_part_1_build_install.md
@@ -189,4 +189,4 @@ sudo make install
 
 ## Next steps:
 
-Now that Valhalla is successfully running in Ubuntu 20.04, head over to our Tutorial [*How to configure and run Valhalla on Ubuntu 20.04*](https://gis-ops.com/valhalla-how-to-run-on-ubuntu-20-04/).
+Now that Valhalla is successfully running in Ubuntu 20.04, head over to our Tutorial [*How to configure and run Valhalla on Ubuntu 20.04*](https://gis-ops.com/valhalla-part-2-how-to-run-valhalla-on-ubuntu/).


### PR DESCRIPTION
I also noticed that the Ubuntu version in the menu does not match the Ubuntu version in the text:

![grafik](https://user-images.githubusercontent.com/10291845/234247585-a6e489a7-c4cd-490a-90bc-a8b928c7d3ca.png)
